### PR TITLE
Add root index.html redirect to reviewer

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url=reviewer/">
+    <title>Philadelphia CAMA Assessment Reviewer</title>
+</head>
+<body>
+    <p>Redirecting to <a href="reviewer/">reviewer</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
GitHub Pages serves from ui/ but had no root index.html, causing a 404. This redirects the root URL straight to reviewer/.

# Description

_Describe your changes and why you're making them. Please include the context, motivation, and relevant dependencies._

Resolves #\[issue\]

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

_Include commands/logs/screenshots as relevant. If there is a command the reviewer can run to test the code, include it here._

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [ ] No action required
- [ ] Actions required (specified below)
